### PR TITLE
Allow overriding launcher particle

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ I am happy if anyone finds this useful. But I have a request: If you learn more 
 - Borrowed a trick from the other mod base (the one by barg and Zed). As you may know, the project dir is found by looking for `jak-project` in the directory path. But if your repository doesn't have that name, it won't be found. They rewrote the function that finds the project directory. But I think it is not working on all platforms yet. I will keep observing their modbase and update this if necessary. What we borrowed for now is working fine on Windows.
 - Improved the debug Nav Mesh display. If you enable 'Nav Mesh Extras', you will see the IDs of the vertexes and the triangles.
 - When you press L2+UP, the HUD now shows the true maximum obtainable number of orbs, flies, and cells instead of the hardcoded values of 2000, 112, and 101.
+- Now you can override which particle a `launcher` should use, using the `part-override` lump (symbol type) - if not specified, or the value you provided does not meet any conditions in the code, then it will continue evaluating the particle choice like vanilla.
+- Added a `*force-launcher-active*` global symbol, to allow forcing all `launcher`s to be active regardless of Jak distance or blue eco status. Useful for checking the particles.
 
 ---
 

--- a/goal_src/jak1/engine/common-obs/generic-obs.gc
+++ b/goal_src/jak1/engine/common-obs/generic-obs.gc
@@ -820,6 +820,8 @@
     (go process-drawable-art-error (the-as string s4-0)))
   (none))
 
+(define *force-launcher-active* #f)
+
 (deftype launcher (process-drawable)
   ((root            collide-shape :override)
    (spring-height   meters)
@@ -1190,6 +1192,7 @@
         (('trans) (move-to-point! (-> self root) (the-as vector (-> block param 0))) (update-transforms! (-> self root)))))
   :trans
     (behavior ()
+      (if *force-launcher-active* (go launcher-active))
       (when (and *target* (>= (-> self active-distance) (vector-vector-distance (-> self root trans) (-> *target* control trans))))
         (cond
           ((send-event *target* 'query 'powerup (pickup-type eco-blue)) (go launcher-active))
@@ -1225,7 +1228,7 @@
       (if (or (or (not *target*)
                   (< (-> self active-distance) (vector-vector-distance (-> self root trans) (-> *target* control trans))))
               (not (send-event *target* 'query 'powerup (pickup-type eco-blue))))
-        (go launcher-idle))
+        (if (not *force-launcher-active*) (go launcher-idle)))
       (spawn (-> self part) (-> self root trans))
       (sound-play "launch-idle" :id (-> self sound-id))
       (if (and (and *target*
@@ -1257,9 +1260,12 @@
   (set! (-> this active-distance) 409600.0)
   (set! (-> this spring-height) (res-lump-float arg0 'spring-height :default 163840.0))
   (let ((s4-1 (res-lump-value arg0 'mode uint128)))
-    (let ((v1-18 (-> this entity extra level name)))
+    (let ((v1-18 (-> this entity extra level name))
+          (part-override (res-lump-struct arg0 'part-override symbol)))
       (set! (-> this part)
             (create-launch-control (cond
+                                     ((= part-override 'beach) (-> *part-group-id-table* 37))
+                                     ((= part-override 'swamp) (-> *part-group-id-table* 39))
                                      ((= v1-18 'beach) (-> *part-group-id-table* 37))
                                      ((= v1-18 'swamp) (-> *part-group-id-table* 39))
                                      (else (-> *part-group-id-table* 38)))
@@ -1295,9 +1301,12 @@
   (update-transforms! (-> self root))
   (set! (-> self spring-height) arg1)
   (set! (-> self active-distance) arg3)
-  (let ((v1-23 (-> self entity extra level name)))
+  (let ((v1-23 (-> self entity extra level name))
+        (part-override (res-lump-struct (-> self entity) 'part-override symbol)))
     (set! (-> self part)
           (create-launch-control (cond
+                                   ((= part-override 'beach) (-> *part-group-id-table* 37))
+                                   ((= part-override 'swamp) (-> *part-group-id-table* 39))
                                    ((= v1-23 'beach) (-> *part-group-id-table* 37))
                                    ((= v1-23 'swamp) (-> *part-group-id-table* 39))
                                    (else (-> *part-group-id-table* 38)))


### PR DESCRIPTION
Allow overriding the particle to be used by any instance of a launcher, using a lump property (`part-override`). If not specified, it will do the level checks that it does in vanilla. So has no impact on original content, but allows creators to take advantage of this feature more easily.

Also added a global symbol `*force-launcher-active*` that will make all launchers active regardless of Jak distance or blue eco status. Very useful if you want to see the particles.